### PR TITLE
[FEATURE] Added --unit as an option to filter on systemd units

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -82,6 +82,14 @@ impl Check {
         cmd.arg("--no-pager")
             .arg(&format!("--since=-{}", self.opt.span))
             .stdin(Stdio::null());
+        if let Some(units) = &self.opt.unit {
+            cmd.args(
+                units
+                    .iter()
+                    .map(|u| format!("--unit={}", u))
+                    .collect::<Vec<_>>(),
+            );
+        }
         if let Some(sf) = &self.opt.statefile {
             cmd.arg(&format!("--cursor-file={}", sf.display()));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ pub struct Opt {
     /// Does not truncate output (opposite of --limit)
     #[structopt(short = "L", long, conflicts_with = "limit")]
     no_limit: bool,
+    /// Filter one or multiple systemd units or patterns. See journalctl --unit.
+    /// Can be specified multiple times.
+    #[structopt(short, long, value_name = "UNIT|PATTERN")]
+    unit: Option<Vec<String>>,
     /// Saves last log position for exact resume
     #[structopt(short = "f", long, value_name = "PATH")]
     statefile: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ pub struct Opt {
     no_limit: bool,
     /// Filter one or multiple systemd units or patterns. See journalctl --unit.
     /// Can be specified multiple times.
-    #[structopt(short, long, value_name = "UNIT|PATTERN")]
+    #[structopt(short, long, number_of_values = 1, value_name = "UNIT|PATTERN")]
     unit: Option<Vec<String>>,
     /// Saves last log position for exact resume
     #[structopt(short = "f", long, value_name = "PATH")]


### PR DESCRIPTION
# Description

I added the possibility to filter on systemd units when calling journalctl. Usually, we are only interested in monitoring a subset of services.

This allows the user to be more flexible in the way the check is configured and may lead to simpler regexes in the rules file.

The unit option follows the style of all the other options, and can be specified multiple times. The values are passed as-is to a sequence of ```journalctl --unit``` options and can therefore contain literal service names or patterns.

```check_journal --span 1d --unit apache2 --unit 'multi*'  /path/to/rules.yaml```

**Note**: I took the decision to limit to 1 the number of argument per occurrence of --unit. If not, clap will try to parse as many arguments as possible leading to invalid parsing.

For instance, this would not parse because /path/to/rules.yaml is considered an argument to the unit option.
```check_journal --unit unit1 unit2 unit3 /path/to/rules.yaml```

This would force you to call the check this way ```check_journal --unit unit1 unit2 unit3 -- /path/to/yaml```

# Tests

- Ubuntu 22.04 amd64, cargo/rustc 1.66.1
  - [x] cargo build --release
  - [x] cargo test
  - [x] manual tests on a running journalctl

- MacOS aarch64-darwin, cargo/rustc 1.71.1 after cargo update
  - [x] cargo build --release
  - [x] cargo test