### PR TITLE
Add --user option.

### DIFF
--- a/man/check_journal.1.ronn
+++ b/man/check_journal.1.ronn
@@ -44,6 +44,8 @@ systems.
 * `-j`, `--journalctl` <PATH>:
     Specifies the journalctl executable.
 
+* `--user`:
+   Search messages from services of the current user.
 
 ## ENVIRONMENT
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -82,6 +82,9 @@ impl Check {
         cmd.arg("--no-pager")
             .arg(&format!("--since=-{}", self.opt.span))
             .stdin(Stdio::null());
+        if self.opt.user {
+            cmd.arg("--user");
+        }
         if let Some(sf) = &self.opt.statefile {
             cmd.arg(&format!("--cursor-file={}", sf.display()));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,9 @@ pub struct Opt {
     /// Does not truncate output (opposite of --limit)
     #[structopt(short = "L", long, conflicts_with = "limit")]
     no_limit: bool,
+    /// Request user unit logs
+    #[structopt(long)]
+    user: bool,
     /// Saves last log position for exact resume
     #[structopt(short = "f", long, value_name = "PATH")]
     statefile: Option<PathBuf>,


### PR DESCRIPTION
Allow check_journal to run in user context / request user logs from journald with --user.